### PR TITLE
ttc-connectors-dummytwitter to 7.1.28

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,3 +10,6 @@ dependencies:
 - name: test1
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.5
+- name: ttc-connectors-dummytwitter
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 7.1.28


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 7.1.28