### PR TITLE
ttc-connectors-dummytwitter to 7.1.31

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.5
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
-  version: 7.1.28
+  version: 7.1.31
 - name: ttc-rb-english-campaign
   repository: http://jenkins-x-chartmuseum:8080
   version: 7.1.31


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 7.1.31