### PR TITLE
ttc-connectors-dummytwitter to 7.1.34

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
   version: 7.1.32
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
-  version: 7.1.30
+  version: 7.1.34
 - name: ttc-rb-english-campaign
   repository: http://jenkins-x-chartmuseum:8080
   version: 7.1.32


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 7.1.34